### PR TITLE
ci: Simplify travis and circle configuration files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,10 +49,8 @@ install:
   - ci before_install
   - ci install
 
-before_script:
-  - ci before_build
-
 script:
+  - ci before_build
   - ci build
   - ci test
 

--- a/circle.yml
+++ b/circle.yml
@@ -10,18 +10,14 @@ dependencies:
   pre:
     - pip install ../bootstrap-scikit-ci/
 
-    - ci before_install
   override:
+    - ci before_install
     - ci install
 
 test:
-  pre:
-    - ci before_build
-
   override:
+    - ci before_build
     - ci build
-
-  post:
     - ci test
 
 deployment:

--- a/docs/scikit-ci-yml.rst
+++ b/docs/scikit-ci-yml.rst
@@ -72,7 +72,7 @@ are know to work.
      :language: yaml
      :start-after: scikit-ci-yml.rst: start
      :end-before: scikit-ci-yml.rst: end
-     :emphasize-lines: 7, 9, 13, 16, 19, 25
+     :emphasize-lines: 6-7, 11-13, 19
 
 
   - ``.travis.yml``
@@ -81,7 +81,7 @@ are know to work.
      :language: yaml
      :start-after: scikit-ci-yml.rst: start
      :end-before: scikit-ci-yml.rst: end
-     :emphasize-lines: 2-3, 6, 9-10, 13
+     :emphasize-lines: 2-3, 6-8, 11
 
 
 Order of steps


### PR DESCRIPTION
Since we are overriding each steps, there is no need to explicitly
add pre/post/before sections.