### PR TITLE
ci: Display normal error message when command fails while executing a step

### DIFF
--- a/ci/__init__.py
+++ b/ci/__init__.py
@@ -7,6 +7,7 @@ extensions.
 
 from .constants import STEPS
 from .driver import execute_step
+from .exceptions import SKCIError
 from ._version import get_versions
 
 __author__ = 'The scikit-build team'
@@ -14,4 +15,4 @@ __email__ = 'scikit-build@googlegroups.com'
 __version__ = get_versions()['version']
 del get_versions
 
-__all__ = ["execute_step", "STEPS"]
+__all__ = ["execute_step", "SKCIError", "STEPS"]

--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -62,8 +62,13 @@ def main():
         help="display scikit-ci version and import information.")
     args = parser.parse_args()
 
-    ci.execute_step(
-        args.step, force=args.force, with_dependencies=args.with_dependencies)
+    try:
+        ci.execute_step(
+            args.step,
+            force=args.force,
+            with_dependencies=args.with_dependencies)
+    except ci.SKCIError as exc:
+        exit(exc)
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/ci/driver.py
+++ b/ci/driver.py
@@ -13,7 +13,7 @@ import shlex
 import subprocess
 import sys
 
-from . import utils
+from . import exceptions, utils
 from .constants import SCIKIT_CI_CONFIG, SERVICES, STEPS
 
 
@@ -268,7 +268,12 @@ class Driver(object):
             # Expand environment variables used within commands
             cmd = self.expand_command(
                 cmd, self.env, posix_shell=posix_shell)
-            self.check_call(cmd.replace("\\\\", "\\\\\\\\"), env=self.env)
+            try:
+                self.check_call(cmd.replace("\\\\", "\\\\\\\\"), env=self.env)
+            except subprocess.CalledProcessError as exc:
+                raise exceptions.SKCIStepExecutionError(
+                    stage_name, exc.returncode, exc.cmd, exc.output
+                )
 
 
 def dependent_steps(step):

--- a/ci/exceptions.py
+++ b/ci/exceptions.py
@@ -1,0 +1,42 @@
+"""
+This module defines exceptions commonly used in scikit-ci.
+"""
+
+import os
+import textwrap
+
+
+class SKCIError(RuntimeError):
+    """Exception raised when an scikit-ci error occurs.
+    """
+    pass
+
+
+class SKCIStepExecutionError(SKCIError):
+    """Exception raised when an error occurs while executing a step.
+    """
+    def __init__(self, step, return_code, cmd, output=None):
+        self.step = step
+        self.return_code = return_code
+        self.cmd = cmd
+        self.output = output
+
+    def __str__(self):
+        return textwrap.dedent(
+            r"""
+            A command failed while executing {step} step.
+              Return code:
+                {return_code}
+              Command:
+                {cmd}
+              Working directory:
+                {cwd}
+
+            Please see above for more information.
+            """.format(
+                step=self.step.upper(),
+                return_code=self.return_code,
+                cmd=self.cmd,
+                cwd=os.getcwd()
+            )
+        )

--- a/tests/test_scikit_ci.py
+++ b/tests/test_scikit_ci.py
@@ -11,6 +11,7 @@ from ruamel.yaml.compat import ordereddict
 from . import captured_lines, display_captured_text, push_dir, push_env
 from ci.constants import SERVICES, SERVICES_ENV_VAR, STEPS
 from ci.driver import Driver, dependent_steps, execute_step
+from ci.exceptions import SKCIStepExecutionError
 from ci.utils import current_service, current_operating_system
 
 """Indicate if the system has a Windows command line interpreter"""
@@ -869,8 +870,8 @@ def test_step_ordering_and_dependency(tmpdir):
         failed = False
         try:
             execute_step("after_test")
-        except subprocess.CalledProcessError as e:
-            failed = "exit(1)" in e.cmd
+        except SKCIStepExecutionError as exc:
+            failed = "exit(1)" in exc.cmd
 
         #
         # Check that `after_test` step was NOT executed. It should not be


### PR DESCRIPTION
Given the following configuration file:

```
schema_version: "0.5.0"
test:
  commands:
    - echo "This work"
    - python -c "raise Exception('Ooops')"
```


Here is the output:

```
$ ci
[scikit-ci] Executing: echo "This work"
This work
[scikit-ci] Executing: python -c "raise Exception('Ooops')"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
Exception: Ooops

A command failed while executing TEST step.
  Return code:
    1
  Command:
    python -c "raise Exception('Ooops')"
  Working directory:
    /tmp

Please see above for more information.
```

Before:

```
$ ci 
[scikit-ci] Executing: echo "This work"
This work
[scikit-ci] Executing: python -c "raise Exception('Ooops')"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
Exception: Ooops
Traceback (most recent call last):
  File "/home/jcfr/.virtualenvs/test-pip-install/bin/ci", line 11, in <module>
    load_entry_point('scikit-ci', 'console_scripts', 'ci')()
  File "/home/jcfr/Projects/scikit-ci/ci/__main__.py", line 66, in main
    args.step, force=args.force, with_dependencies=args.with_dependencies)
  File "/home/jcfr/Projects/scikit-ci/ci/driver.py", line 310, in execute_step
    execute_step(depends[-1], with_dependencies=with_dependencies)
  File "/home/jcfr/Projects/scikit-ci/ci/driver.py", line 314, in execute_step
    d.execute_commands(step)
  File "/home/jcfr/Projects/scikit-ci/ci/driver.py", line 271, in execute_commands
    self.check_call(cmd.replace("\\\\", "\\\\\\\\"), env=self.env)
  File "/home/jcfr/Projects/scikit-ci/ci/driver.py", line 83, in check_call
    return subprocess.check_call(*args, **kwds)
  File "/usr/lib/python2.7/subprocess.py", line 540, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command 'python -c "raise Exception('Ooops')"' returned non-zero exit status 1
```