### PR TITLE
ci: Add "true" support for multi-line command

### DIFF
--- a/ci/driver.py
+++ b/ci/driver.py
@@ -14,6 +14,11 @@ import subprocess
 import sys
 import tempfile
 
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
+
 from pyfiglet import Figlet
 
 from . import exceptions, utils
@@ -359,8 +364,16 @@ class Driver(object):
         for cmd in commands:
             language = "default"
             if isinstance(cmd, dict):
-                language = list(cmd.keys())[0]
-                cmd = list(cmd.values())[0]
+                # Prevent output of debug message.
+                # Workaround https://bitbucket.org/ruamel/yaml/pull-requests/13
+                try:
+                    oldout = sys.stdout
+                    sys.stdout = StringIO()
+                    language = list(cmd.keys())[0]
+                    cmd = list(cmd.values())[0]
+                finally:
+                    sys.stdout = oldout
+
             else:
                 # Expand environment variables used within commands
                 posix_shell = "COMSPEC" not in os.environ

--- a/docs/scikit-ci-yml.rst
+++ b/docs/scikit-ci-yml.rst
@@ -256,6 +256,8 @@ Reserved Environment Variables
     contain the name of the continuous integration service currently executing
     the step.
 
+.. _environment_variable_usage:
+
 Environment variable usage
 --------------------------
 
@@ -313,3 +315,33 @@ The output on the different service will be the following:
 
           .. autoclass:: ci.driver.Driver
              :members: expand_command
+
+
+Python Commands
+---------------
+
+.. versionadded:: 0.10.0
+
+The ``python`` commands are supported on all platforms.
+
+For example:
+
+.. code-block:: yaml
+
+  test:
+    commands:
+      - python: print("single_line")
+      - python: "for letter in ['a', 'b', 'c']: print(letter)"
+      - python: |
+                import os
+                if 'FOO' in os.environ:
+                    print("FOO is set")
+                else:
+                    print("FOO is *NOT* set")
+
+
+.. note::
+
+    By using ``os.environ``, they remove the need for specifying environment
+    variable using the ``$<NAME_OF_VARIABLE>`` syntax described in
+    :ref:`environment_variable_usage`.


### PR DESCRIPTION
It is now possible to specify python command as depicted in the
example below.

Note that the scikit-ci-schema still need to been updated to validate
against python command. See scikit-build/scikit-ci-schema#1

```yml
test:
  commands:
    - python: print("single_line")
    - python: "for letter in ['a', 'b', 'c']: print(letter)"
    - python: |
              for index in range(3):
                  with open("file_%s" % index, "w") as output:
                      output.write("")
```