### PR TITLE
scikit-ci: Update PATH, remove use of $<PYTHON> and directly use executables

### DIFF
--- a/ci/driver.py
+++ b/ci/driver.py
@@ -111,7 +111,7 @@ class Driver(object):
 
     class PythonCommandConfig(object):
         shell = "python"
-        subprocess_shell_mode = False
+        subprocess_shell_mode = True
         shell_options = ["-B"]
         use_script = True
         script_suffix = ".py"
@@ -165,6 +165,8 @@ class Driver(object):
                 shell_cmd = [cmd_config.shell]
                 shell_cmd.extend(cmd_config.shell_options)
                 shell_cmd.append(script_file.name)
+                if cmd_config.subprocess_shell_mode:
+                    shell_cmd = " ".join(['"%s"' % arg for arg in shell_cmd])
                 args = [shell_cmd]
                 # And finally execute
                 subprocess.check_call(*args, **kwds)

--- a/scikit-ci.yml
+++ b/scikit-ci.yml
@@ -2,13 +2,9 @@ schema_version: "0.5.0"
 
 before_install:
 
-  environment:
-    PYTHON: python
-    RUN_ENV: ""
-
   appveyor:
     environment:
-      PYTHON: $<PYTHON_DIR>\\python.exe
+      PATH: $<PYTHON_DIR>;$<PYTHON_DIR>\\Scripts;$<PATH>
 
   travis:
     osx:
@@ -19,28 +15,23 @@ before_install:
 
 install:
   commands:
-    - $<RUN_ENV> $<PYTHON> -m pip install --disable-pip-version-check --upgrade pip
-    - $<RUN_ENV> $<PYTHON> -m pip install -r requirements.txt
-    - $<RUN_ENV> $<PYTHON> -m pip install -r requirements-dev.txt
+    - $<RUN_ENV> python -m pip install --disable-pip-version-check --upgrade pip
+    - $<RUN_ENV> pip install -r requirements.txt
+    - $<RUN_ENV> pip install -r requirements-dev.txt
 
 before_build:
   commands:
-    - $<RUN_ENV> $<PYTHON> -m flake8
+    - $<RUN_ENV> flake8
 
 build:
   commands:
-    - $<RUN_ENV> $<PYTHON> setup.py build
+    - $<RUN_ENV> python setup.py sdist
+    - $<RUN_ENV> python setup.py bdist_wheel
 
 test:
-
-  appveyor:
-    environment:
-      PATH: $<PYTHON_DIR>\\Scripts;$<PATH>
-
   commands:
-    - $<RUN_ENV> $<PYTHON> setup.py test
+    - $<RUN_ENV> python setup.py test
 
 after_test:
   commands:
     - $<RUN_ENV> codecov -X gcov --required --file ./tests/coverage.xml
-    - $<RUN_ENV> $<PYTHON> setup.py bdist_wheel


### PR DESCRIPTION
Also remove explicit setting of RUN_ENV to an empty var. This became
unneeded after e48e300 (ci: Expand unset scikit-ci env variable used
in command to an empty string)