### PR TITLE
fix ruamel.yaml on 0.14.X for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,11 +41,14 @@ cache:
 before_install:
   - |
     BOOTSTRAP_BRANCH=$TRAVIS_PULL_REQUEST_BRANCH
+    BOOTSTRAP_REPO_SLUG=$TRAVIS_PULL_REQUEST_SLUG
     if [[ $BOOTSTRAP_BRANCH == "" ]]; then
       BOOTSTRAP_BRANCH=$TRAVIS_BRANCH
+      BOOTSTRAP_REPO_SLUG=$TRAVIS_REPO_SLUG
     fi
     echo "BOOTSTRAP_BRANCH:$BOOTSTRAP_BRANCH"
-    git clone git://github.com/scikit-build/scikit-ci -b $BOOTSTRAP_BRANCH ../boostrap-scikit-ci
+    echo "BOOTSTRAP_REPO_SLUG:$BOOTSTRAP_REPO_SLUG"
+    git clone git://github.com/$BOOTSTRAP_REPO_SLUG -b $BOOTSTRAP_BRANCH ../boostrap-scikit-ci
     pip install -U ../boostrap-scikit-ci
 
   - pip install scikit-ci-addons==0.11.0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,8 +7,6 @@ branches:
 version: "0.0.1.{build}"
 
 environment:
-  GH_CMDLINE_TOKEN:
-    secure: 8qYavC/JSRbc77YFoPEyjD8jaBjNGRXyBMjXQAIYi6En1ymsG0Mucxt1m79osNc0
   matrix:
 
     - PYTHON_DIR: "C:\\Python27-x64"
@@ -25,9 +23,10 @@ init:
 
   - ps: |
         $env:BOOTSTRAP_BRANCH = $env:APPVEYOR_REPO_BRANCH
+        $env:BOOTSTRAP_REPO_SLUG = $env:APPVEYOR_REPO_NAME
         if($env:APPVEYOR_PULL_REQUEST_NUMBER -ne $null) {
           #
-          # Since AppVeyor provides only the PR numbder, retrieve
+          # Since AppVeyor provides only the PR number, retrieve
           # PR branch name directly from GitHub
           #
           # See also https://developer.github.com/v3/pulls/#get-a-single-pull-request
@@ -36,16 +35,18 @@ init:
           $env:BOOTSTRAP_BRANCH=(Invoke-WebRequest            `
             -Uri $GitHubUri                                  `
             -Headers @{                                      `
-              "Authorization"="token $env:GH_CMDLINE_TOKEN"; `
               "Accept"= "application/vnd.github.v3.raw"      `
             } | ConvertFrom-Json).head.ref
+          $env:BOOTSTRAP_REPO_SLUG=(Invoke-WebRequest            `
+            -Uri $GitHubUri                                  `
+            -Headers @{                                      `
+              "Accept"= "application/vnd.github.v3.raw"      `
+            } | ConvertFrom-Json).head.repo.full_name
         }
+        Write-Host "BOOTSTRAP_REPO_SLUG:$env:BOOTSTRAP_REPO_SLUG"
         Write-Host "BOOTSTRAP_BRANCH:$env:BOOTSTRAP_BRANCH"
 
-        # Clear GH_CMDLINE_TOKEN variable
-        Remove-Item Env:GH_CMDLINE_TOKEN
-
-  - git clone git://github.com/scikit-build/scikit-ci -b %BOOTSTRAP_BRANCH% ../bootstrap-scikit-ci
+  - git clone git://github.com/%BOOTSTRAP_REPO_SLUG% -b %BOOTSTRAP_BRANCH% ../bootstrap-scikit-ci
   - python.exe -m pip install -U ../bootstrap-scikit-ci/
 
 # scikit-ci-yml.rst: start

--- a/circle.yml
+++ b/circle.yml
@@ -6,8 +6,15 @@ machine:
 dependencies:
   override:
     - |
-      echo "CIRCLE_BRANCH:$CIRCLE_BRANCH"
-      git clone git://github.com/scikit-build/scikit-ci -b $CIRCLE_BRANCH ../bootstrap-scikit-ci
+      BOOTSTRAP_BRANCH=$CIRCLE_BRANCH
+      BOOTSTRAP_REPO_SLUG=$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME
+      if [[ $CIRCLE_PR_USERNAME != "" ]]; then
+        BOOTSTRAP_BRANCH=$(curl -s https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls/${CIRCLE_PR_NUMBER} | jq -r '.head.ref')
+        BOOTSTRAP_REPO_SLUG=$CIRCLE_PR_USERNAME/$CIRCLE_PR_REPONAME
+      fi
+      echo "BOOTSTRAP_BRANCH:$BOOTSTRAP_BRANCH"
+      echo "BOOTSTRAP_REPO_SLUG:$BOOTSTRAP_REPO_SLUG"
+      git clone git://github.com/$BOOTSTRAP_REPO_SLUG -b $BOOTSTRAP_BRANCH ../bootstrap-scikit-ci
       pip install -U ../bootstrap-scikit-ci
 
     - ci install

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 pyfiglet
-ruamel.yaml
+ruamel.yaml<0.15


### PR DESCRIPTION
Thank you for using ruamel.yaml. 

There will be API changes in the 0.15+ versions, that might lead to warnings that 
your users could see. 
Therefore please release a version of your package with this change, so that it will not 
automatically take the latest ruamel.yaml release.