### PR TITLE
ci: Add support for ruamel.yaml >= 0.15.52

### DIFF
--- a/ci/driver.py
+++ b/ci/driver.py
@@ -14,6 +14,7 @@ import subprocess
 import sys
 import tempfile
 
+from collections import MutableMapping
 try:
     from StringIO import StringIO
 except ImportError:
@@ -397,7 +398,7 @@ class Driver(object):
 
         for cmd in commands:
             language = "default"
-            if isinstance(cmd, dict):
+            if isinstance(cmd, MutableMapping):
                 # Prevent output of debug message.
                 # Workaround https://bitbucket.org/ruamel/yaml/pull-requests/13
                 try:

--- a/tests/test_scikit_ci.py
+++ b/tests/test_scikit_ci.py
@@ -1135,6 +1135,7 @@ def test_python_cmd(tmpdir, capfd):
           commands:
             - python: print("single_line")
             - python: "for letter in ['a', 'b', 'c']: print(letter)"
+            # This is a comment
             - python: |
                       for index in range(3):
                           with open("file_%s" % index, "w") as output:


### PR DESCRIPTION
This commit fixes error like the following:


Traceback (most recent call last):

  File "/usr/local/bin/ci", line 11, in <module>
    sys.exit(main())
  File "/usr/local/lib/python2.7/site-packages/ci/__main__.py", line 74, in main
    clear_cached_env=args.clear_cached_env
  File "/usr/local/lib/python2.7/site-packages/ci/driver.py", line 467, in execute_step
    execute_step(depends[-1], with_dependencies=with_dependencies)
  File "/usr/local/lib/python2.7/site-packages/ci/driver.py", line 471, in execute_step
    d.execute_commands(step)
  File "/usr/local/lib/python2.7/site-packages/ci/driver.py", line 415, in execute_commands
    cmd, self.env, posix_shell=posix_shell).strip()
  File "/usr/local/lib/python2.7/site-packages/ci/driver.py", line 293, in expand_command
    command = command.replace("\\\n", "")
AttributeError: 'CommentedMap' object has no attribute 'replace'