### PR TITLE
Fix "ruamel.yaml" requirement specification

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ details, see the commit logs at http://github.com/scikit-build/scikit-ci
 Next Release
 ============
 
+* Fix installation of using Python 3.4
+
 Scikit-ci 0.20.0
 ================
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 pyfiglet
-ruamel.yaml>=0.15
+ruamel.yaml>=0.15;python_version == '2.7'
+ruamel.yaml>=0.15,<=0.15.94;python_version == '3.4'
+ruamel.yaml>=0.15;python_version > '3.4'


### PR DESCRIPTION
Since no python 3.4 wheel are distributed following ruamel.yaml 0.15.94,
this commit updates the requirements to ensure the package still be installed
using python 3.4